### PR TITLE
Initialize IBC keepers in FundChain app

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -180,6 +180,10 @@ func New(
 		&app.ConsensusParamsKeeper,
 		&app.CircuitBreakerKeeper,
 		&app.ParamsKeeper,
+		&app.IBCKeeper,
+		&app.ICAControllerKeeper,
+		&app.ICAHostKeeper,
+		&app.TransferKeeper,
 		&app.FundchainKeeper,
 		&app.MilestonesKeeper,
 	); err != nil {


### PR DESCRIPTION
## Summary
- wire IBC-related keepers in `App` constructor so dependency injection initializes them

## Testing
- `go test ./app -run TestNonExist` *(fails: command stalled, possibly due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d1a46f488330b945dcf067ab9360